### PR TITLE
Turn off cross-origin protection

### DIFF
--- a/lib/main.rb
+++ b/lib/main.rb
@@ -16,6 +16,8 @@ pingdom = Decider::Pingdom.new(
 
 final_decider = FinalDecider.new([ci, pingdom])
 
+set :protection, :except => :frame_options
+
 put "/:value" do |value|
   if params["token"] != ENV["CAN_I_BUMP_TOKEN"]
     status 401


### PR DESCRIPTION
so that industrious developers can render canibump in an iframe.
