### PR TITLE
Introduce canibump API

### DIFF
--- a/lib/deciders/ci.rb
+++ b/lib/deciders/ci.rb
@@ -3,7 +3,7 @@ module Decider
     attr_reader :reason, :build_number
 
     def initialize
-      @value == false
+      @value = false
       @reason = "CI: no data yet"
       @build_number = -1
     end

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -41,6 +41,10 @@ put "/:value" do |value|
   status 200
 end
 
-get "/" do
+get "/", :provides => 'html' do
   erb :main, :locals => { can_i_bump: final_decider.can_i_bump?, reasons: final_decider.reasons, build_number: ci.build_number }
+end
+
+get "/", :provides => 'json' do
+  { can_i_bump: final_decider.can_i_bump? }.to_json
 end

--- a/spec/deciders/ci_spec.rb
+++ b/spec/deciders/ci_spec.rb
@@ -5,6 +5,10 @@ describe Decider::CI do
   subject(:ci) { described_class.new }
 
   describe "#can_i_bump?" do
+    it "returns false by default" do
+      expect(ci.can_i_bump?).to eq false
+    end
+
     context "when the build number is the latest encountered" do
       context "when can i bump set to yes" do
         before do

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -22,21 +22,35 @@ describe "Sinatra Application" do
   end
 
   describe "GET /" do
-    it "returns no by default" do
-      response = make_get_request
-      expect(response.body).to match /NO/
-      expect(response.body).to match /no data yet/
-    end
-
-    context "when the value is set to no" do
-      before do
-        make_put_request("no?reason=idunno&buildnumber=123")
-      end
-
-      it "returns no and prints outs the reason" do
+    context "as an HTML request" do
+      it "returns no by default" do
         response = make_get_request
         expect(response.body).to match /NO/
-        expect(response.body).to match /idunno/
+        expect(response.body).to match /no data yet/
+      end
+
+      context "when the value is set to no" do
+        before do
+          make_put_request("no?reason=idunno&buildnumber=123")
+        end
+
+        it "returns no and prints outs the reason" do
+          response = make_get_request
+          expect(response.body).to match /NO/
+          expect(response.body).to match /idunno/
+        end
+      end
+    end
+
+    context "as a JSON request" do
+      it "returns the can_i_bump status" do
+        response = make_get_request(accept: :json)
+
+        content_type = response.headers[:content_type]
+        expect(content_type).to eq 'application/json'
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response).to eq({ "can_i_bump" => false })
       end
     end
   end

--- a/spec/support/can_i_bump_runner.rb
+++ b/spec/support/can_i_bump_runner.rb
@@ -24,8 +24,8 @@ module CanIBumpRunner
     graceful_kill(@app_pid)
   end
 
-  def make_get_request
-    RestClient.get app_url
+  def make_get_request(accept: :html)
+    RestClient.get(app_url, accept: accept)
   end
 
   def make_put_request(path)


### PR DESCRIPTION
The buildpacks team would like to be able to pull the canibump status programmatically. This introduces a simple API which allows us to do so.
